### PR TITLE
修复测试用例不能直接使用的问题

### DIFF
--- a/helper/bench/Makefile
+++ b/helper/bench/Makefile
@@ -1,6 +1,7 @@
 # All targets.
 default: bench
 
+# configure these paths according to you system
 bench: /usr/local/bin/go /etc/redis/redis.conf /usr/local/bin/docker-compose main.go
 	rm -f ../conf.sample.yml
 	go build -o bench

--- a/helper/bench/prepare.sh
+++ b/helper/bench/prepare.sh
@@ -6,5 +6,5 @@ git clone https://github.com/dtm-labs/dtm.git && cd dtm && git checkout alpha &&
 
 echo 'all prepared. you shoud run following commands to test in different terminal'
 echo
-echo 'cd dtm && go run bench/main.go redis|boltdb|db'
-echo 'cd dtm && bench/run-redis|boltdb|mysql.sh'
+echo 'cd dtf && go run helper/bench/main.go redis|boltdb|db'
+echo 'cd dtf/helper && bench/run-redis|boltdb|mysql.sh'

--- a/helper/bench/prepare.sh
+++ b/helper/bench/prepare.sh
@@ -7,4 +7,4 @@ git clone https://github.com/dtm-labs/dtm.git && cd dtm && git checkout alpha &&
 echo 'all prepared. you shoud run following commands to test in different terminal'
 echo
 echo 'cd dtf && go run helper/bench/main.go redis|boltdb|db'
-echo 'cd dtf/helper && bench/run-redis|boltdb|mysql.sh'
+echo 'cd dtf && ./helper/bench/test-redis|boltdb|mysql.sh'

--- a/helper/bench/svr/http.go
+++ b/helper/bench/svr/http.go
@@ -96,7 +96,7 @@ func PrepareBenchDB() {
 func StartSvr() {
 	app := dtmutil.GetGinApp()
 	benchAddRoute(app)
-	logger.Debugf("bench listening at %d", benchPort)
+	logger.Infof("bench listening at %s", benchPort)
 	go func() {
 		_ = app.Run(fmt.Sprintf(":%s", benchPort))
 	}()

--- a/helper/bench/svr/http.go
+++ b/helper/bench/svr/http.go
@@ -73,7 +73,9 @@ var sqls = 1
 // PrepareBenchDB prepares db data for bench
 func PrepareBenchDB() {
 	db := pdbGet()
-	_, err := dtmimp.DBExec(db, "drop table if exists dtm_busi.user_account_log")
+	_, err := dtmimp.DBExec(db, "CREATE DATABASE if not exists dtm_busi")
+	logger.FatalIfError(err)
+	_, err = dtmimp.DBExec(db, "drop table if exists dtm_busi.user_account_log")
 	logger.FatalIfError(err)
 	_, err = dtmimp.DBExec(db, `create table if not exists dtm_busi.user_account_log (
 	id      INT(11) AUTO_INCREMENT PRIMARY KEY,

--- a/test/busi/startup.go
+++ b/test/busi/startup.go
@@ -22,6 +22,8 @@ func PopulateDB(skipDrop bool) {
 	dtmutil.RunSQLScript(BusiConf, file, skipDrop)
 	file = fmt.Sprintf("%s/dtmcli.barrier.%s.sql", dtmutil.GetSQLDir(), BusiConf.Driver)
 	dtmutil.RunSQLScript(BusiConf, file, skipDrop)
+	file = fmt.Sprintf("%s/dtmsvr.storage.%s.sql", dtmutil.GetSQLDir(), BusiConf.Driver)
+	dtmutil.RunSQLScript(BusiConf, file, skipDrop)
 	_, err := RedisGet().FlushAll(context.Background()).Result() // redis barrier need clear
 	dtmimp.E2P(err)
 	SetRedisBothAccount(10000, 10000)


### PR DESCRIPTION
1. 修复测试前没有运行dtm系统sql的问题
2. 修复PrepareBenchDB可能出现的database not exist 问题
3. 把旧的命令修改为新的